### PR TITLE
Update the multi-container demo app. for live-1

### DIFF
--- a/kubernetes_deploy/ingress.yaml
+++ b/kubernetes_deploy/ingress.yaml
@@ -4,6 +4,9 @@ metadata:
   name: multi-container-demo
   namespace: davids-dummy-dev
 spec:
+  tls:
+  - hosts:
+    - multi-container-demo.apps.cloud-platform-live-0.k8s.integration.dsd.io
   rules:
   - host: multi-container-demo.apps.cloud-platform-live-0.k8s.integration.dsd.io
     http:

--- a/kubernetes_deploy/ingress.yaml
+++ b/kubernetes_deploy/ingress.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   tls:
   - hosts:
-    - multi-container-demo.apps.cloud-platform-live-0.k8s.integration.dsd.io
+    - multi-container-demo.apps.live-1.cloud-platform.service.justice.gov.uk
   rules:
-  - host: multi-container-demo.apps.cloud-platform-live-0.k8s.integration.dsd.io
+  - host: multi-container-demo.apps.live-1.cloud-platform.service.justice.gov.uk
     http:
       paths:
       - path: /


### PR DESCRIPTION
This PR adds a tls section to the ingress, and changes the hostname to what
it will be on the live-1 cluster.