### PR TITLE
Add HTTP basic authentication to the app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Deploying this application to the [MoJ cloud platform][cloudplatform] demonstrat
 * Setting up an RDS instance
 * Adding deployment secrets (the RDS database credentials)
 * Running database migrations
+* Putting HTTP basic authentication in front of development apps. on *.service.justice.gov.uk domains
+
+For the HTTP basic authentication, the default user is 'myuser' with password 'password123'.
+
+See the tutorial on [adding basic authentication] for details of how to change this.
 
 ## Running the application locally
 
@@ -44,3 +49,4 @@ Every ten seconds, the displayed message should change (you will need to refresh
 [docker]: https://docker.io
 [docker-compose]: https://docs.docker.com/compose/
 [rds]: https://aws.amazon.com/rds/
+[adding basic authentication]: https://user-guide.cloud-platform.service.justice.gov.uk/tasks.html#add-http-basic-authentication

--- a/kubernetes_deploy/ingress.yaml
+++ b/kubernetes_deploy/ingress.yaml
@@ -2,7 +2,9 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: multi-container-demo
-  namespace: davids-dummy-dev
+  annotations:
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: basic-auth
 spec:
   tls:
   - hosts:

--- a/kubernetes_deploy/secret.yaml
+++ b/kubernetes_deploy/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: basic-auth
+data:
+  # username: myuser, password: password123
+  # https://user-guide.cloud-platform.service.justice.gov.uk/tasks.html#add-http-basic-authentication
+  auth: bXl1c2VyOiRhcHIxJGc2R0JJaHNiJEc3cTE4SDJGRGVSUnNKdEZFOWIwVDAK


### PR DESCRIPTION
This ensures that, by default, deployments of this
application onto the cloud platform will comply
with this guidance:

https://ministryofjustice.github.io/technical-guidance/standards/naming-domains/#justicegovuk

Related to: https://github.com/ministryofjustice/cloud-platform/issues/917