### PR TITLE
Bind app to 0.0.0.0 and refer docker hub images

### DIFF
--- a/kubernetes_deploy/content-api-deployment.yaml
+++ b/kubernetes_deploy/content-api-deployment.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: content-api
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/davids-dummy-team/davids-dummy-app:content-api-1.3
+        image: ministryofjustice/cloud-platform-multi-container-demo-app:content-api-1.4
         ports:
         - containerPort: 4567

--- a/kubernetes_deploy/rails-app-deployment.yaml
+++ b/kubernetes_deploy/rails-app-deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: rails-app
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/davids-dummy-team/davids-dummy-app:rails-app-1.3
+        image: ministryofjustice/cloud-platform-multi-container-demo-app:rails-app-1.4
         ports:
         - containerPort: 3000
         env:

--- a/kubernetes_deploy/rails-migrations-job.yaml
+++ b/kubernetes_deploy/rails-migrations-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: rails-app
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/davids-dummy-team/davids-dummy-app:rails-app-1.3
+        image: ministryofjustice/cloud-platform-multi-container-demo-app:rails-app-1.4
         command: [ "bundle", "exec", "rails", "db:migrate" ]
         env:
           - name: DATABASE_URL

--- a/kubernetes_deploy/worker-deployment.yaml
+++ b/kubernetes_deploy/worker-deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: worker
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/davids-dummy-team/davids-dummy-app:worker-1.3
+        image: ministryofjustice/cloud-platform-multi-container-demo-app:worker-1.4
         ports:
         - containerPort: 4567
         env:

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
-TEAM_NAME := davids-dummy-team
-REPO_NAME := davids-dummy-app
-VERSION := 1.3
+TEAM_NAME := ministryofjustice
+REPO_NAME := cloud-platform-multi-container-demo-app
+VERSION := 1.4
 
 COMPONENTS := rails-app content-api worker
 ECR := 754256621582.dkr.ecr.eu-west-2.amazonaws.com/$(TEAM_NAME)/$(REPO_NAME)
@@ -12,12 +12,12 @@ build-images:
 
 tag-images:
 	for component in $(COMPONENTS); do \
-		docker tag $(TEAM_NAME)/$(REPO_NAME):$${component} $(ECR):$${component}-$(VERSION); \
+		docker tag $(TEAM_NAME)/$(REPO_NAME):$${component} $(TEAM_NAME)/$(REPO_NAME):$${component}-$(VERSION); \
 	done
 
 push-images:
 	for component in $(COMPONENTS); do \
-		docker push $(ECR):$${component}-$(VERSION); \
+		docker push $(TEAM_NAME)/$(REPO_NAME):$${component}-$(VERSION); \
 	done
 
 build-tag-and-push:

--- a/makefile
+++ b/makefile
@@ -3,7 +3,6 @@ REPO_NAME := cloud-platform-multi-container-demo-app
 VERSION := 1.4
 
 COMPONENTS := rails-app content-api worker
-ECR := 754256621582.dkr.ecr.eu-west-2.amazonaws.com/$(TEAM_NAME)/$(REPO_NAME)
 
 build-images:
 	for component in $(COMPONENTS); do \

--- a/rails-app/Dockerfile
+++ b/rails-app/Dockerfile
@@ -21,4 +21,4 @@ RUN chown -R appuser:appgroup /app/db
 
 USER 1000
 
-CMD ["rails", "server"]
+CMD ["rails", "server", "-b", "0.0.0.0"]


### PR DESCRIPTION
The app doesnot work correctly without 0.0.0.0 binding when deployed to kubernetes.

- fix dockerfile to bind 0.0.0.0
- Use dockerhub to refer images
- bump image tag to use the latest one.