### PR TITLE
Apiversion update for kubernetes 1.16

### DIFF
--- a/helm_deploy/multi-container-app/templates/content-api/deployment.yaml
+++ b/helm_deploy/multi-container-app/templates/content-api/deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: content-api
 spec:
   replicas: {{ .Values.contentapi.replicaCount }}
+  selector:
+    matchLabels:
+      app: content-api
   template:
     metadata:
       labels:

--- a/helm_deploy/multi-container-app/templates/rails-app/deployment.yaml
+++ b/helm_deploy/multi-container-app/templates/rails-app/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rails-app

--- a/helm_deploy/multi-container-app/templates/rails-app/deployment.yaml
+++ b/helm_deploy/multi-container-app/templates/rails-app/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: rails-app
 spec:
   replicas: {{ .Values.railsapp.replicaCount }}
+  selector:
+    matchLabels:
+      app: rails-app
   template:
     metadata:
       labels:

--- a/helm_deploy/multi-container-app/templates/rails-app/ingress.yaml
+++ b/helm_deploy/multi-container-app/templates/rails-app/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: multi-container-app

--- a/helm_deploy/multi-container-app/templates/worker/deployment.yaml
+++ b/helm_deploy/multi-container-app/templates/worker/deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: worker
 spec:
   replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      app: worker
   template:
     metadata:
       labels:

--- a/kubernetes_deploy/content-api-deployment.yaml
+++ b/kubernetes_deploy/content-api-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: content-api
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: content-api
   template:
     metadata:
       labels:

--- a/kubernetes_deploy/ingress.yaml
+++ b/kubernetes_deploy/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: multi-container-demo

--- a/kubernetes_deploy/rails-app-deployment.yaml
+++ b/kubernetes_deploy/rails-app-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rails-app
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: rails-app
   template:
     metadata:
       labels:

--- a/kubernetes_deploy/rails-migrations-job.yaml
+++ b/kubernetes_deploy/rails-migrations-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: rails-app
-        image: ministryofjustice/cloud-platform-multi-container-demo-app:rails-app-1.4
+        image: ministryofjustice/cloud-platform-multi-container-demo-app:rails-app-1.5
         command: [ "bundle", "exec", "rails", "db:migrate" ]
         env:
           - name: DATABASE_URL

--- a/kubernetes_deploy/worker-deployment.yaml
+++ b/kubernetes_deploy/worker-deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: worker
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: worker
   template:
     metadata:
       labels:


### PR DESCRIPTION
Update ApiVersion for deployment and ingress as they are deprecated in kubernetes 1.16.

Related to: https://github.com/ministryofjustice/cloud-platform/issues/1943