### PR TITLE
Add ingress class annotation

### DIFF
--- a/kubernetes_deploy/ingress.yaml
+++ b/kubernetes_deploy/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: basic-auth
+    kubernetes.io/ingress.class: nginx
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
This is not strictly necessary, but we use ingress class to determine which ingress controller an ingress is defined on, so it makes sense to include it so that developers get accustomed to seeing it.