### PR TITLE
More ingress api v1 external-dns annotation fixes

### DIFF
--- a/kubernetes_deploy/ingress.yaml
+++ b/kubernetes_deploy/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: multi-container-demo
@@ -6,6 +6,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: basic-auth
     kubernetes.io/ingress.class: nginx
+    external-dns.alpha.kubernetes.io/set-identifier: <ingress-name>-<namespace-name>-green
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
   - hosts:
@@ -14,7 +16,10 @@ spec:
   - host: multi-container-demo.apps.live.cloud-platform.service.justice.gov.uk
     http:
       paths:
-      - path: /
-        backend:
-          serviceName: rails-app-service
-          servicePort: 3000
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: rails-app-service
+                port: 
+                  number: 3000


### PR DESCRIPTION
As per Helm chart fixes, regular kubernetes ingress manifest updates